### PR TITLE
Fixed crash if setting `show_screen`

### DIFF
--- a/util.lua
+++ b/util.lua
@@ -58,7 +58,7 @@ local function match_clients(str)
       end
 
       if options.show_screen then
-        menu_entry = menu_entry .. "(" .. string.match(screen, "%d") .. ") "
+        menu_entry = menu_entry .. "(" .. string.match(screen.index, "%d") .. ") "
       end
 
       menu_entry = menu_entry .. c.name


### PR DESCRIPTION
Something must've changed in recent awesomewm versions, if this option was set it would crash trying to display the screen object (no longer just an ID). Luckily we can grab the ID without too much trouble and fix it nicely.