### PR TITLE
Fix nil access on client name

### DIFF
--- a/util.lua
+++ b/util.lua
@@ -61,7 +61,10 @@ local function match_clients(str)
         menu_entry = menu_entry .. "(" .. string.match(screen.index, "%d") .. ") "
       end
 
-      menu_entry = menu_entry .. c.name
+      if c.name then
+         menu_entry = menu_entry .. c.name
+      end
+
       table.insert(clients, { menu_entry, function()
                                 client.focus = c
                                 c:raise()


### PR DESCRIPTION
Some client windows like the toolbar (Form Controls) of Libre Office don't
have a name. The string concatenation with nil leads to an error and breaks
the whole menu.

    error: /home/joerg/.config/awesome/cheeky/util.lua:64: attempt to concatenate a nil value (field 'name')